### PR TITLE
Filter all values of a multi-valued field for control chars

### DIFF
--- a/library/Solarium/Core/Query/Helper.php
+++ b/library/Solarium/Core/Query/Helper.php
@@ -486,7 +486,18 @@ class Helper
      */
     public function filterControlCharacters($data)
     {
-        return preg_replace('@[\x00-\x08\x0B\x0C\x0E-\x1F]@', ' ', $data);
+        $controlRegex = '@[\x00-\x08\x0B\x0C\x0E-\x1F]@';
+        if (is_array($data)){
+            foreach ($data as &$d){
+                if(is_string($d)){
+                    $d = preg_replace($controlRegex, ' ', $d);
+                }
+            }
+        }
+        else if (is_string($data)){
+            $data =  preg_replace($controlRegex, ' ', $data);
+        }
+        return $data;
     }
 
     /**

--- a/library/Solarium/QueryType/Update/Query/Document/Document.php
+++ b/library/Solarium/QueryType/Update/Query/Document/Document.php
@@ -195,7 +195,7 @@ class Document extends AbstractDocument implements DocumentInterface
                 $this->fields[$key] = array($this->fields[$key]);
             }
 
-            if ($this->filterControlCharacters && is_string($value)) {
+            if ($this->filterControlCharacters) {
                 $value = $this->getHelper()->filterControlCharacters($value);
             }
 
@@ -228,7 +228,7 @@ class Document extends AbstractDocument implements DocumentInterface
         if ($value === null && $modifier === null) {
             $this->removeField($key);
         } else {
-            if ($this->filterControlCharacters && is_string($value)) {
+            if ($this->filterControlCharacters) {
                 $value = $this->getHelper()->filterControlCharacters($value);
             }
 

--- a/tests/Solarium/Tests/Core/Query/HelperTest.php
+++ b/tests/Solarium/Tests/Core/Query/HelperTest.php
@@ -437,5 +437,11 @@ class HelperTest extends \PHPUnit_Framework_TestCase
             'my string',
             $this->helper->filterControlCharacters("my\x08string")
         );
+
+        $this->assertEquals(
+            array('my string', 'moi string'),
+            $this->helper->filterControlCharacters(
+                array("my\x08string", "moi\x08string"))
+        );
     }
 }


### PR DESCRIPTION
This small change ensures that all values see control character filtering.

When setting a field to an array, checking control characters was skipped.
